### PR TITLE
- Importing the main file files when used as a dependency because the

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@iml/router",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@iml/router",
-  "version": "6.1.0",
-  "main": "source/get-router.js",
+  "version": "6.1.1",
+  "main": "dist/get-router.js",
   "description": "A simple utility to route requests to actions.",
   "scripts": {
     "test": "jest -c ./jest.config.js",
     "eslint": "eslint ./",
     "cover": "NODE_ENV=test npm test -- --coverage",
     "format": "prettier --write '**/*.js'",
-    "postversion": "rm -rf dist && parcel build source/get-router.js --log-level=3 --detailed-report"
+    "postversion": "rm -rf dist && parcel build source/get-router.js"
   },
   "pre-commit": [
     "eslint",


### PR DESCRIPTION
"main" property in package.json needs to point to "dist/get-router.js"
instead of "source/get-router.js".

Signed-off-by: Will Johnson <wjohnson@whamcloud.com>